### PR TITLE
fix hibernate sequence

### DIFF
--- a/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Course.java
+++ b/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Course.java
@@ -1,15 +1,6 @@
 package pl.edu.agh.iisg.to.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -22,7 +13,15 @@ public class Course {
     public static final String TABLE_NAME = "course";
 
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE)
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "course_gen")
+    @TableGenerator(
+            name = "course_gen",
+            table = "id_generator",
+            pkColumnName = "gen_name",
+            valueColumnName = "gen_value",
+            pkColumnValue = "course_seq",
+            allocationSize = 1
+    )
     @Column(name = Columns.ID)
     private int id;
 

--- a/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Grade.java
+++ b/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Grade.java
@@ -1,15 +1,7 @@
 package pl.edu.agh.iisg.to.model;
 
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.util.Objects;
 
@@ -20,7 +12,15 @@ public class Grade {
     public static final String TABLE_NAME = "grade";
 
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE)
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "grade_gen")
+    @TableGenerator(
+            name = "grade_gen",
+            table = "id_generator",
+            pkColumnName = "gen_name",
+            valueColumnName = "gen_value",
+            pkColumnValue = "grade_seq",
+            allocationSize = 1
+    )
     @Column(name = Columns.ID)
     private int id;
 

--- a/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Student.java
+++ b/lab02-orm/src/main/java/pl/edu/agh/iisg/to/model/Student.java
@@ -12,7 +12,15 @@ public class Student {
 
     public static final String TABLE_NAME = "student";
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE)
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "student_gen")
+    @TableGenerator(
+            name = "student_gen",
+            table = "id_generator",
+            pkColumnName = "gen_name",
+            valueColumnName = "gen_value",
+            pkColumnValue = "student_seq",
+            allocationSize = 1
+    )
     @Column(name = Columns.ID)
     private int id;
     @Column(name = Columns.FIRST_NAME, nullable = false, length = 50)


### PR DESCRIPTION
The error occurs because Hibernate is trying to create a default sequence for each table individually, which leads to conflicts when the same sequence name (like default) is used across multiple entities. By using the TableGenerator, a separate sequence is created for each table.